### PR TITLE
some miscellaneous cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Creates a cursor object for an incoming signal and executes one command per sign
 
 Properties
 ----------
-- **connection**: userid, password, server, port, database, mars
+- **connection**: user_id, password, server, port, database, mars
 - **enrich**: enable signal enrichment
 - **id**: block id
 - **table**: database table to be affected
@@ -35,7 +35,7 @@ Creates a cursor object for every list of signals, and executes one query per si
 
 Properties
 ----------
-- **connection**: userid, password, server, port, database, mars
+- **connection**: user_id, password, server, port, database, mars
 - **enrich**: enable signal enrichment
 - **id**: block id
 - **table**: database table to be affected
@@ -66,7 +66,7 @@ Creates a cursor object for every list of signals, and executes one query per si
 
 Properties
 ----------
-- **connection**: userid, password, server, port, database, mars
+- **connection**: user_id, password, server, port, database, mars
 - **enrich**: enable signal enrichment
 - **id**: block id
 - **table**: database table to be affected
@@ -98,7 +98,7 @@ Creates a cursor object for every list of signals, and executes one update per s
 
 Properties
 ----------
-- **connection**: userid, password, server, port, database, mars
+- **connection**: user_id, password, server, port, database, mars
 - **enrich**: enable signal enrichment
 - **id**: block id
 - **table**: database table to be affected
@@ -125,7 +125,7 @@ Creates a cursor object for every list of signals, and executes one query per si
 
 Properties
 ----------
-- **connection**: userid, password, server, port, database, mars
+- **connection**: user_id, password, server, port, database, mars
 - **enrich**: enable signal enrichment
 - **id**: block id
 - **query**: parameterized SQL query to execute

--- a/mssql_base.py
+++ b/mssql_base.py
@@ -8,7 +8,7 @@ class Connection(PropertyHolder):
     server = StringProperty(title='Server', default='[[MSSQL_SERVER]]', order=1)
     port = IntProperty(title='Port', default='[[MSSQL_PORT]]', order=2)
     database = StringProperty(title='Database', default='[[MSSQL_DB]]', order=3)
-    userid = StringProperty(title='User ID', allow_none=True, default='[[MSSQL_USER]]', order=4)
+    user_id = StringProperty(title='User ID', allow_none=True, default='[[MSSQL_USER]]', order=4)
     password = StringProperty(title="Password", allow_none=True, default='[[MSSQL_PWD]]', order=5)
     mars = BoolProperty(title='Enable Multiple Active Result Sets', default=False, order=6)
 
@@ -42,7 +42,7 @@ class MSSQLBase(Block):
                 cnxn_props.port(),
                 cnxn_props.server(),
                 cnxn_props.database(),
-                cnxn_props.userid(),
+                cnxn_props.user_id(),
                 'yes' if cnxn_props.mars() else 'no',
                 cnxn_props.password())
         self.logger.debug('Connecting: {}'.format(cnxn_string))

--- a/mssql_conditions.py
+++ b/mssql_conditions.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from nio.properties import ListProperty, Property, SelectProperty, StringProperty, PropertyHolder
 
+
 class Operator(Enum):
     EQ = '='
     GT = '>'
@@ -9,20 +10,23 @@ class Operator(Enum):
     LTE = '<='
     NOT = '!='
 
+
 class AndOrOperator(Enum):
     AND = 'AND'
     OR = 'OR'
+
 
 class Conditions(PropertyHolder):
     column = StringProperty(title='Column', order=20)
     operation = SelectProperty(Operator, title='Operator', default="EQ", order=21)
     value = Property(title='Value', order=22)
 
+
 class MSSQLConditions(object):
     conditions = ListProperty(Conditions, title='Conditions', deafult=[], order=14)
     combine_condition = SelectProperty(AndOrOperator, title='Combine Condition', default="AND", order=15)
 
-    def get_where_conditions(self, signal, table, cursor):
+    def _get_where_conditions(self, signal, table, cursor):
         conditions = ""
         combine_condition = self.combine_condition().value
         params = []
@@ -32,7 +36,9 @@ class MSSQLConditions(object):
             else:
                 conditions += ' {} '.format(combine_condition)
 
-            condition_string = '{} {} ?'.format(self.validate_column(condition.column(signal), table, cursor), condition.operation(signal).value)
+            column = self.validate_column(condition.column(signal), table, cursor)
+            condition_string = '{} {} ?'.format(column, condition.operation(signal).value)
+
             conditions += condition_string
             params.append(condition.value(signal))
         return conditions, params

--- a/mssql_delete_block.py
+++ b/mssql_delete_block.py
@@ -1,42 +1,36 @@
 from nio.properties import VersionProperty, StringProperty
 from nio.signal.base import Signal
-from .mssql_base import MSSQLBase
+
+from .mssql_base import MSSQLTabledBase
 from .mssql_conditions import MSSQLConditions
 
 
-class MSSQLDelete(MSSQLBase, MSSQLConditions):
-
+class MSSQLDelete(MSSQLTabledBase, MSSQLConditions):
     version = VersionProperty("1.0.0")
-    table = StringProperty(title='Table', default='{{ $table }}', order=5)
 
-    def process_signals(self, signals):
-        if self.isConnecting:
-            self.logger.error(
-                'Connection already in progress. Dropping signals.')
-        else:
-            try:
-                cursor = self.cnxn.cursor()
-            except Exception as e:
-                self.disconnect()
-                self.connect()
-                cursor = self.cnxn.cursor()
+    def process_signals(self, signals, **kwargs):
+        if self.is_connecting:
+            self.logger.error('Connection already in progress. Dropping signals.')
+            return
 
-            total_rows = 0
-            for signal in signals:
-                # determine query to execute
-                table = self.table(signal)
-                conditions, params = \
-                    self.get_where_conditions(signal, table, cursor)
-                command = 'DELETE FROM {}'.format(table) + conditions
-                self.logger.debug('Executing: {} with params {}'.format(
-                    command, params))
+        cursor = self._get_cursor()
 
-                row_count = cursor.execute(command, params).rowcount
-                self.logger.debug('{} rows returned for signal: {}'.
-                                  format(row_count, signal.to_dict()))
-                total_rows += row_count
+        total_rows = 0
+        for signal in signals:
+            # determine query to execute
+            table = self.table(signal)
+            conditions, params = \
+                self._get_where_conditions(signal, table, cursor)
+            command = 'DELETE FROM {}'.format(table) + conditions
+            self.logger.debug('Executing: {} with params {}'.format(
+                command, params))
 
-            self.logger.debug('Rows deleted: {}'.format(total_rows))
-            cursor.close()
+            row_count = cursor.execute(command, params).rowcount
+            self.logger.debug('{} rows returned for signal: {}'.
+                              format(row_count, signal.to_dict()))
+            total_rows += row_count
 
-            self.notify_signals([Signal({'Rows deleted': total_rows})])
+        self.logger.debug('Rows deleted: {}'.format(total_rows))
+        cursor.close()
+
+        self.notify_signals([Signal({'Rows deleted': total_rows})])

--- a/mssql_insert_block.py
+++ b/mssql_insert_block.py
@@ -1,50 +1,43 @@
-from nio.properties import VersionProperty, Property, StringProperty
-from .mssql_base import MSSQLBase
+from nio.properties import VersionProperty, Property
 from nio.block.mixins.enrich.enrich_signals import EnrichSignals
 
+from .mssql_base import MSSQLTabledBase
 
-class MSSQLInsert(EnrichSignals, MSSQLBase):
-
+class MSSQLInsert(EnrichSignals, MSSQLTabledBase):
     version = VersionProperty("1.0.0")
-    table = StringProperty(title='Table', default='{{ $table }}', order=5)
     row = Property(title='Row', default='{{ $.to_dict() }}', order=6)
 
-    def process_signals(self, signals):
-        if self.isConnecting:
-            self.logger.error(
-                'Connection already in progress. Dropping signals.')
-        else:
-            output_signals = []
-            try:
-                cursor = self.cnxn.cursor()
-            except Exception as e:
-                self.disconnect()
-                self.connect()
-                cursor = self.cnxn.cursor()
+    def process_signals(self, signals, **kwargs):
+        if self.is_connecting:
+            self.logger.error('Connection already in progress. Dropping signals.')
+            return
 
-            inserted = 0
-            for signal in signals:
-                row_dict = self.row(signal)
-                cols = ''
-                vals = ''
-                for key in row_dict:
-                    cols += key + ', '
-                    val = row_dict[key]
-                    if isinstance(val, str):
-                        # double-up quote chars to escape without backslash hell
-                        val = val.replace('\'', '\'\'').replace('\"', '\"\"')
-                        val = '\'' + val + '\''
-                    vals += str(val) + ', '
-                query = 'INSERT INTO {} ({}) VALUES ({});'.format(
-                    self.table(signal),
-                    cols[:-2],
-                    vals[:-2])
-                self.logger.debug('Executing: {}'.format(query))
-                result = cursor.execute(query)
-                inserted += result.rowcount
-                output_signals.append(self.get_output_signal(
-                    {'inserted': inserted}, signal))
-            cursor.commit()
-            cursor.close()
-            self.logger.debug('Rows committed: {}'.format(inserted))
-            self.notify_signals(output_signals)
+        output_signals = []
+        cursor = self._get_cursor()
+
+        inserted = 0
+        for signal in signals:
+            row_dict = self.row(signal)
+            cols = ''
+            vals = ''
+            for key in row_dict:
+                cols += key + ', '
+                val = row_dict[key]
+                if isinstance(val, str):
+                    # double-up quote chars to escape without backslash hell
+                    val = val.replace('\'', '\'\'').replace('\"', '\"\"')
+                    val = '\'' + val + '\''
+                vals += str(val) + ', '
+            query = 'INSERT INTO {} ({}) VALUES ({});'.format(
+                self.table(signal),
+                cols[:-2],
+                vals[:-2])
+            self.logger.debug('Executing: {}'.format(query))
+            result = cursor.execute(query)
+            inserted += result.rowcount
+            output_signals.append(self.get_output_signal(
+                {'inserted': inserted}, signal))
+        cursor.commit()
+        cursor.close()
+        self.logger.debug('Rows committed: {}'.format(inserted))
+        self.notify_signals(output_signals)

--- a/mssql_query_block.py
+++ b/mssql_query_block.py
@@ -1,54 +1,49 @@
 from nio.properties import VersionProperty, StringProperty
 from nio.block.terminals import output
-from .mssql_base import MSSQLBase
-from .mssql_conditions import MSSQLConditions
 from nio.block.mixins.enrich.enrich_signals import EnrichSignals
+
+from .mssql_base import MSSQLTabledBase
+from .mssql_conditions import MSSQLConditions
 
 
 @output('results', label='Results')
 @output('no_results', label='No Results')
-class MSSQLQuery(EnrichSignals, MSSQLBase, MSSQLConditions):
+class MSSQLQuery(EnrichSignals, MSSQLTabledBase, MSSQLConditions):
 
     version = VersionProperty("1.0.0")
-    table = StringProperty(title='Table', default='{{ $table }}', order=5)
 
-    def process_signals(self, signals):
-        if self.isConnecting:
-            self.logger.error(
-                'Connection already in progress. Dropping signals.')
+    def process_signals(self, signals, **kwargs):
+        if self.is_connecting:
+            self.logger.error('Connection already in progress. Dropping signals.')
+            return
+
+        cursor = self._get_cursor()
+
+        output_signals = []
+        for signal in signals:
+            # determine query to execute
+            table = self.table(signal)
+            conditions, params = \
+                self._get_where_conditions(signal, table, cursor)
+            query = 'SELECT * FROM {}'.format(table) + conditions
+            self.logger.debug('Executing: {} with params {}'.format(
+                query, params))
+
+            rows = cursor.execute(query, params).fetchall()
+            self.logger.debug('{} rows returned for signal: {}'.
+                              format(len(rows), signal.to_dict()))
+            for row in rows:
+                hashed_row = zip([r[0] for r in cursor.description],
+                                 row)
+                signal_dict = {a: b for a, b in hashed_row}
+                output_signals.append(
+                    self.get_output_signal(signal_dict, signal))
+
+        cursor.close()
+
+        if len(output_signals) > 0:
+            self.notify_signals(output_signals, output_id='results')
         else:
-            try:
-                cursor = self.cnxn.cursor()
-            except Exception as e:
-                self.disconnect()
-                self.connect()
-                cursor = self.cnxn.cursor()
-
-            output_signals = []
-            for signal in signals:
-                # determine query to execute
-                table = self.table(signal)
-                conditions, params = \
-                    self.get_where_conditions(signal, table, cursor)
-                query = 'SELECT * FROM {}'.format(table) + conditions
-                self.logger.debug('Executing: {} with params {}'.format(
-                    query, params))
-
-                rows = cursor.execute(query, params).fetchall()
-                self.logger.debug('{} rows returned for signal: {}'.
-                                  format(len(rows), signal.to_dict()))
-                for row in rows:
-                    hashed_row = zip([r[0] for r in cursor.description],
-                                     row)
-                    signal_dict = {a: b for a, b in hashed_row}
-                    output_signals.append(
-                        self.get_output_signal(signal_dict, signal))
-
-            cursor.close()
-
-            if len(output_signals) > 0:
-                self.notify_signals(output_signals, output_id='results')
-            else:
-                output_signals.append(self.get_output_signal(
-                    {'results': 'null'}, signals[0]))
-                self.notify_signals(output_signals, output_id='no_results')
+            output_signals.append(self.get_output_signal(
+                {'results': 'null'}, signals[0]))
+            self.notify_signals(output_signals, output_id='no_results')

--- a/mssql_rawquery_block.py
+++ b/mssql_rawquery_block.py
@@ -8,43 +8,45 @@ from nio.block.mixins.enrich.enrich_signals import EnrichSignals
 class MSSQLRawQuery(EnrichSignals, MSSQLBase):
 
     version = VersionProperty("1.0.0")
-    query = StringProperty(title='Parameterized Query (use ? for any user-supplied values)', default='SELECT * FROM table where id=?', order=10)
-    parameters = Property(title='Substitution Parameters (As List, In Order)', default='{{[]}}', order=11)
+    query = StringProperty(
+        title='Parameterized Query (use ? for any user-supplied values)',
+        default='SELECT * FROM table where id=?',
+        order=1)
+    parameters = Property(
+        title='Substitution Parameters (As List, In Order)',
+        default='{{[]}}',
+        order=2)
 
-    def process_signals(self, signals):
-        if self.isConnecting:
+    def process_signals(self, signals, **kwargs):
+        if self.is_connecting:
             self.logger.error('Connection already in progress. Dropping signals.')
-        else:
+            return
+
+        cursor = self._get_cursor()
+
+        output_signals = []
+
+        for signal in signals:
+            _query = self.query(signal)
+            _parameters = self.parameters(signal)
+
+            result = cursor.execute(_query, _parameters) if len(_parameters) > 0 else cursor.execute(_query)
+
             try:
-                cursor = self.cnxn.cursor()
-            except Exception as e:
-                self.disconnect()
-                self.connect()
-                cursor = self.cnxn.cursor()
+                rows = result.fetchall()
+                for row in rows:
+                    hashed_row = zip([r[0] for r in cursor.description],row)
+                    signal_dict = {a: b for a, b in hashed_row}
+                    output_signals.append(self.get_output_signal(signal_dict, signal))
 
-            output_signals = []
+            except Exception:
+                output_signals.append(self.get_output_signal({'inserted': result.rowcount}, signal))
 
-            for signal in signals:
-                _query = self.query(signal)
-                _parameters = self.parameters(signal)
+        cursor.commit()
+        cursor.close()
 
-                result = cursor.execute(_query, _parameters) if len(_parameters) > 0 else cursor.execute(_query)
-
-                try:
-                    rows = result.fetchall()
-                    for row in rows:
-                        hashed_row = zip([r[0] for r in cursor.description],row)
-                        signal_dict = {a: b for a, b in hashed_row}
-                        output_signals.append(self.get_output_signal(signal_dict, signal))
-
-                except Exception:
-                    output_signals.append(self.get_output_signal({'inserted': result.rowcount}, signal))
-
-            cursor.commit()
-            cursor.close()
-
-            if len(output_signals) > 0:
-                self.notify_signals(output_signals, output_id='results')
-            else:
-                output_signals.append(self.get_output_signal({'results': 'null'}, signals[0]))
-                self.notify_signals(output_signals, output_id='no_results')
+        if len(output_signals) > 0:
+            self.notify_signals(output_signals, output_id='results')
+        else:
+            output_signals.append(self.get_output_signal({'results': 'null'}, signals[0]))
+            self.notify_signals(output_signals, output_id='no_results')

--- a/mssql_update_block.py
+++ b/mssql_update_block.py
@@ -1,61 +1,54 @@
 from nio.properties import VersionProperty, StringProperty, PropertyHolder, Property, ListProperty
 from nio.signal.base import Signal
-from .mssql_base import MSSQLBase
+
+from .mssql_base import MSSQLTabledBase
 from .mssql_conditions import MSSQLConditions
 
 
 class ColumnValue(PropertyHolder):
-
     column = StringProperty(title='Column', order=20)
     value = Property(title='Value', order=21)
 
 
-class MSSQLUpdate(MSSQLBase, MSSQLConditions):
-
+class MSSQLUpdate(MSSQLTabledBase, MSSQLConditions):
     version = VersionProperty("1.0.0")
-    table = StringProperty(title='Table', default='{{ $table }}', order=5)
     column_values = ListProperty(ColumnValue, title='Column Values', default=[], order=11)
 
-    def process_signals(self, signals):
-        if self.isConnecting:
+    def process_signals(self, signals, **kwargs):
+        if self.is_connecting:
             self.logger.error(
                 'Connection already in progress. Dropping signals.')
-        else:
-            try:
-                cursor = self.cnxn.cursor()
-            except Exception as e:
-                self.disconnect()
-                self.connect()
-                cursor = self.cnxn.cursor()
+            return
 
-            total_rows = 0
-            for signal in signals:
-                # determine query to execute
-                table = self.table(signal)
-                column_values, params = \
-                    self._get_column_values(signal, table, cursor)
-                conditions, where_params = \
-                    self.get_where_conditions(signal, table, cursor)
-                params.extend(where_params)
-                update = \
-                    'UPDATE {} SET {}'.format(table, column_values) + conditions
-                self.logger.debug('Executing: {} with params {}'.format(
-                    update, params))
+        cursor = self._get_cursor()
 
-                row_count = cursor.execute(update, params).rowcount
-                self.logger.debug('{} rows returned for signal: {}'.
-                                  format(row_count, signal.to_dict()))
-                total_rows += row_count
+        total_rows = 0
+        for signal in signals:
+            # determine query to execute
+            table = self.table(signal)
+            column_values, params = \
+                self._get_column_values(signal, table, cursor)
+            conditions, where_params = \
+                self._get_where_conditions(signal, table, cursor)
+            params.extend(where_params)
+            update = \
+                'UPDATE {} SET {}'.format(table, column_values) + conditions
+            self.logger.debug('Executing: {} with params {}'.format(
+                update, params))
 
-            self.logger.debug('Rows updated: {}'.format(total_rows))
+            row_count = cursor.execute(update, params).rowcount
+            self.logger.debug('{} rows returned for signal: {}'.
+                              format(row_count, signal.to_dict()))
+            total_rows += row_count
 
-            cursor.commit()
-            cursor.close()
+        self.logger.debug('Rows updated: {}'.format(total_rows))
 
-            self.notify_signals([Signal({'Rows updated': total_rows})])
+        cursor.commit()
+        cursor.close()
+
+        self.notify_signals([Signal({'Rows updated': total_rows})])
 
     def _get_column_values(self, signal, table, cursor):
-
         column_values = ""
         params = []
         for i, column_value in enumerate(self.column_values()):

--- a/spec.json
+++ b/spec.json
@@ -11,7 +11,7 @@
         "type": "ObjectType",
         "description": "Connection Details",
         "default": {
-          "userid": "[[MSSQL_USER]]",
+          "user_id": "[[MSSQL_USER]]",
           "password": "[[MSSQL_PWD]]",
           "server": "[[MSSQL_SERVER]]",
           "port": "[[MSSQL_PORT]]",
@@ -71,7 +71,7 @@
         "type": "ObjectType",
         "description": "Connection Details",
         "default": {
-          "userid": "[[MSSQL_USER]]",
+          "user_id": "[[MSSQL_USER]]",
           "password": "[[MSSQL_PWD]]",
           "server": "[[MSSQL_SERVER]]",
           "port": "[[MSSQL_PORT]]",
@@ -131,7 +131,7 @@
         "type": "ObjectType",
         "description": "Connection Details",
         "default": {
-          "userid": "[[MSSQL_USER]]",
+          "user_id": "[[MSSQL_USER]]",
           "password": "[[MSSQL_PWD]]",
           "server": "[[MSSQL_SERVER]]",
           "port": "[[MSSQL_PORT]]",
@@ -194,7 +194,7 @@
         "type": "ObjectType",
         "description": "Connection Details",
         "default": {
-          "userid": "[[MSSQL_USER]]",
+          "user_id": "[[MSSQL_USER]]",
           "password": "[[MSSQL_PWD]]",
           "server": "[[MSSQL_SERVER]]",
           "port": "[[MSSQL_PORT]]",
@@ -260,7 +260,7 @@
         "type": "ObjectType",
         "description": "Connection Details",
         "default": {
-          "userid": "[[MSSQL_USER]]",
+          "user_id": "[[MSSQL_USER]]",
           "password": "[[MSSQL_PWD]]",
           "server": "[[MSSQL_SERVER]]",
           "port": "[[MSSQL_PORT]]",

--- a/tests/test_mssql_delete_block.py
+++ b/tests/test_mssql_delete_block.py
@@ -20,7 +20,7 @@ class TestMSSQL(NIOBlockTestCase):
           'server': _host,
           'port': _port,
           'database': _db,
-          'userid': _uid,
+          'user_id': _uid,
           'password': _pw,
           'mars': _mars,
         },

--- a/tests/test_mssql_insert_block.py
+++ b/tests/test_mssql_insert_block.py
@@ -20,7 +20,7 @@ class TestMSSQLInsert(NIOBlockTestCase):
           'server': _host,
           'port': _port,
           'database': _db,
-          'userid': _uid,
+          'user_id': _uid,
           'password': _pw,
           'mars': _mars,
         },

--- a/tests/test_mssql_query_block.py
+++ b/tests/test_mssql_query_block.py
@@ -19,7 +19,7 @@ class TestMSSQL(NIOBlockTestCase):
           'server': _host,
           'port': _port,
           'database': _db,
-          'userid': _uid,
+          'user_id': _uid,
           'password': _pw,
           'mars': _mars,
         },

--- a/tests/test_mssql_rawquery_block.py
+++ b/tests/test_mssql_rawquery_block.py
@@ -19,7 +19,7 @@ class TestMSSQL(NIOBlockTestCase):
           'server': _host,
           'port': _port,
           'database': _db,
-          'userid': _uid,
+          'user_id': _uid,
           'password': _pw,
           'mars': _mars,
         },

--- a/tests/test_mssql_update_block.py
+++ b/tests/test_mssql_update_block.py
@@ -20,7 +20,7 @@ class TestMSSQLUpdate(NIOBlockTestCase):
           'server': _host,
           'port': _port,
           'database': _db,
-          'userid': _uid,
+          'user_id': _uid,
           'password': _pw,
           'mars': _mars,
         },


### PR DESCRIPTION
feel free to merge this or just use it as a guide. 

- extract protected `_get_cursor()` method from each derived class
- add a `MSSQLTabledBase` class to replace the old class hierarchy 
  - encapsulates the `table` property and column validation functionality
- rename some properties and field to pythonic form
  - `userid` to `user_id`
  - `isConnecting` to `is_connecting`
- fix some whitespace
- remove some dead code
  -  base had a unused `cursor` field
- short circuiting `is_connected` check in derived blocks to flatten indentation